### PR TITLE
Accelerate Travis by removing some steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,10 @@ matrix:
 
   include:
 
-  - rust: nightly
+  # Use a hardcoded nightly version for fmt, so that changes
+  # to rustfmt have to be made explicitly, avoiding random fmt
+  # failures if rustfmt updates.
+  - rust: nightly-2019-06-30
     before_script:
     - rustup component add rustfmt-preview
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,4 @@ cache:
   - "$HOME/.cargo"
 
 script:
-- cargo check --all
 - cargo test --all
-- cargo build --all


### PR DESCRIPTION
`cargo check` and `cargo build` are subsets of `cargo test`, so by only running tests we can cut the CI time to roughly 1/3.  This also checks the `cargo fmt` version into git so that if rustfmt changes the format rules, we'll get that when we explicitly update it, rather than having random fmt errors.