### PR TITLE
Log rustc, cargo, rustup versions before executing build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN cargo fetch --verbose
 
 COPY . .
 
-RUN cargo test --all && cargo build --release
+RUN rustc -V; cargo -V; rustup -V; cargo test --all && cargo build --release


### PR DESCRIPTION
Since we pin our build/deploy container to rust:stretch, which pulls in the latest rust:stable by default, our rustc will change under us when a new rust:stable is available, possibly changing the output of our builds and making them noisier. They shouldn't _break_, but still, it's good to know what changed when the build log 'suddenly' starts to look different.

It's possible that we might want to pin a version of rust or the upstream container in the future and use a smart job similar to Dependabot to open a pull request that will upgrade and test the new version of Rust before we merge it, but since Rust stable versions are supposed to be, well, stable, this is less of a concern than our cargo dependencies.

Fixes #146