### PR TITLE
make each step be indented 1 space

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,18 +8,18 @@ jobs:
     name: Google Cloud Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: Authenticate w/ Google Cloud
-      uses: actions/gcloud/auth@master
-      env:
-        GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
-    - name: Build, Test, Push to GCR
-      uses: actions/gcloud/cli@master
-      with:
-        entrypoint: sh
-        args: -l -c "SHORT_SHA=$(echo ${{ github.sha }} | head -c7) && BRANCH_NAME=$(git
-          name-rev --name-only HEAD) && gcloud builds submit . --config cloudbuild.yaml
-          --project zealous-zebra --substitutions BRANCH_NAME=$BRANCH_NAME"
+     - uses: actions/checkout@master
+     - name: Authenticate w/ Google Cloud
+       uses: actions/gcloud/auth@master
+       env:
+         GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
+     - name: Build, Test, Push to GCR
+       uses: actions/gcloud/cli@master
+       with:
+         entrypoint: sh
+         args: -l -c "SHORT_SHA=$(echo ${{ github.sha }} | head -c7) && BRANCH_NAME=$(git
+           name-rev --name-only HEAD) && gcloud builds submit . --config cloudbuild.yaml
+           --project zealous-zebra --substitutions BRANCH_NAME=$BRANCH_NAME"
     # If this is uncommented, it will pull the image it `uses` even if the
     # conditional expression evaluates to 'false'.
     #

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,11 +11,11 @@ steps:
 #   - '-c'
 #   - |
 #     docker run gcr.io/kaniko-project/warmer:latest --image=gcr.io/$PROJECT_ID/$BRANCH_NAME:latest --image=gcr.io/$PROJECT_ID/master:latest || exit 0
-- name: 'gcr.io/kaniko-project/executor:latest'
-  args:
-  - --destination=gcr.io/$PROJECT_ID/$BRANCH_NAME #:$SHORT_SHA
-  - --cache=true
-  - --cache-ttl=12h
+ - name: 'gcr.io/kaniko-project/executor:latest'
+   args:
+    - --destination=gcr.io/$PROJECT_ID/$BRANCH_NAME #:$SHORT_SHA
+    - --cache=true
+    - --cache-ttl=12h
 
 options:
     machineType: 'N1_HIGHCPU_32'


### PR DESCRIPTION
I was inspired by my confusion around the properties #167 of Github Actions `steps` to propose this style change.
I believe the interesting upshot is that there's bug in this doc:

https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idsteps

I'll pursue that bug, elsewhere.   Rejection of this PR won't affect that process.

A second motivation for opening this PR is to observe the action it provokes in the Zebra CI/CD system.